### PR TITLE
Fix Japanese Language Code Mismatch from "jp" to "ja"

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -25,7 +25,7 @@ const LanguageSwitcher = () => {
     setCurrentLanguage(savedLanguage);
 
     const urlLanguage = pathname.split("/")[1];
-    if (["en", "ar", "zh", "es", "jp"].includes(urlLanguage)) {
+    if (["en", "ar", "zh", "es", "ja"].includes(urlLanguage)) {
       setCurrentLanguage(urlLanguage);
     }
   }, [pathname]);
@@ -35,7 +35,7 @@ const LanguageSwitcher = () => {
     document.cookie = `NEXT_LOCALE=${newLanguage}; path=/;`;
 
     const segments = pathname.split("/");
-    if (["en", "ar", "zh", "es", "jp"].includes(segments[1])) {
+    if (["en", "ar", "zh", "es", "ja"].includes(segments[1])) {
       segments[1] = newLanguage;
     } else {
       segments.splice(1, 0, newLanguage);
@@ -50,7 +50,7 @@ const LanguageSwitcher = () => {
     ar: "العربية",
     zh: "中文",
     es: "Español",
-    jp: "日本語",
+    ja: "日本語",
   };
 
   return (
@@ -73,7 +73,7 @@ const LanguageSwitcher = () => {
         <DropdownMenuItem onClick={() => changeLanguage("es")}>
           Español
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => changeLanguage("jp")}>
+        <DropdownMenuItem onClick={() => changeLanguage("ja")}>
           日本語
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -2,7 +2,7 @@ import { defineRouting } from "next-intl/routing";
 
 export const routing = defineRouting({
   // A list of all locales that are supported
-  locales: ["en", "ar", "zh", "es", "jp"],
+  locales: ["en", "ar", "zh", "es", "ja"],
 
   // Used when no locale matches
   defaultLocale: "en",


### PR DESCRIPTION
Corrected Japanese language code from "jp" to "ja" in two files to fix site crash on language switch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the Japanese locale to “ja” (was “jp”) across the app.
  * Updated language switcher options and behavior to use “ja”.
  * Adjusted URL/path handling so Japanese routes appear under “/ja”.
  * Ensured the visible label remains “日本語” for the Japanese option.
  * Updated supported locales configuration to include “ja” instead of “jp”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->